### PR TITLE
Avoid creating an extra structures subdirectory in copy_dir().

### DIFF
--- a/build.pl
+++ b/build.pl
@@ -124,7 +124,7 @@ sub build_changa {
 	make_path($dest);
 	
 	use ChaNGa::Util qw(copy_dir);
-	copy_dir("$args{'changa-dir'}/../utility/structures", "$dest/structures");
+	copy_dir("$args{'changa-dir'}/../utility/structures/.", "$dest/structures");
 	execute("cd $dest/structures && make clean 2>&1 >/dev/null");
 
 	my $begin = Benchmark->new();


### PR DESCRIPTION
I had to use this fix on Piz Daint as well (Cray XC with perl 5.18.2)